### PR TITLE
Support Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ powershell -command "Get-Process -IncludeUserName
  | ConvertTo-Csv -NoTypeInformation"
 `````
 
+Confirmed versions are:
+
+|  Windows version               |  PowerShell version information                                           | Note                                          |
+| ------------------------------ | ------------------------------------------------------------------------- |-----------------------------------------------|
+|  Windows 10 10.0.19042 (20H2)  |  PSVersion: 5.1.19041.906 (default installed version), PSEdition: Desktop | `powershell_command` as `powershell` (default)|
+|  Windows 10 10.0.19042 (20H2)  |  PSVersion: 7.1.2, PSEdition: Core                                        | `powershell_command` as `pwsh`                |
+
+
 Here are details of this default command.
 
 * `Get-Process -IncludeUserName`

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ $ tail -f /var/log/td-agent/td-agent.log
   * output record keys of the ps command results
   * [default] Linux, MacOSX: `start_time,user,pid,parent_pid,cpu_time,cpu_percent,memory_percent,mem_rss,mem_size,state,proc_name,command`
     * need to modify `command` too if you modify this value.
-  * [default] Windows: `start_time,user,sid,pid,cpu_second,working_set,virtual_memory_size,handles,proc_name`
-    * in Windows only, you can fix this without fixing `command`, unless you specify a key other than the default.
-    * `user` key needs administrator privilege. You can exclude this to avoid needing administrator privilege.
+  * [default] Windows: `StartTime,UserName,SessionId,Id,CPU,WorkingSet,VirtualMemorySize,HandleCount,ProcessName`
+    * in Windows only, you can fix this without fixing `command`. These keys can be specified from the properties of `System.Diagnostics.Process` object of `.NET`.
+    * `UserName` key needs administrator privilege. You can exclude this to avoid needing administrator privilege.
 
 * types (Optional)
   * settings of converting types from string to integer/float.
   * [default] Linux, MacOSX: `pid:integer,parent_pid:integer,cpu_percent:float,memory_percent:float,mem_rss:integer,mem_size:integer`
-  * [default] Windows: `sid:integer,pid:integer,cpu_second:float,working_set:integer,virtual_memory_size:integer,handles:integer`
+  * [default] Windows: `SessionId:integer,Id:integer,CPU:float,WorkingSet:integer,VirtualMemorySize:integer,HandleCount:integer`
 
 * interval (Optional)
   * execute interval time
@@ -117,14 +117,14 @@ Here are details of this default command.
 
 * `Get-Process -IncludeUserName`
   * `Get-Process` powershell command takes `System.Diagnostics.Process` objects.
-  * `IncludeUserName` option is needed to take `UserName` (key:`user`).
+  * `IncludeUserName` option is needed to take `UserName`.
     * this needs administrator privilege.
-    * this will be omitted if `keys` does not contain `user`.
+    * this will be omitted if `keys` does not contain `UserName`.
 * ` | ?{$_.StartTime -ne $NULL -and $_.CPU -ne $NULL}`
   * this exlcludes some special processes that don't have some properties, such as the "Idle" process in Windows.
 * ` | Select-Object -Property ...`
   * this takes the necessary parameters from `System.Diagnostics.Process` objects.
-  * `...` part will be automatically fixed by `keys`, unless you specify a key other than the default.
+  * `...` part will be automatically fixed by `keys`.
 * ` | %{$_.StartTime = ...; return $_;}`
   * this fixes locale of `StartTime` value to `en-US`.
   * note: in Windows, setting the "$env:Lang" environment variable is not effective in changing the format of the output.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ $ tail -f /var/log/td-agent/td-agent.log
 
 ### About Windows
 
-Default `command` in Windows below is complicated, but you can fix `keys` without fixing `command`, unless you specify a key other than the default.
+Default `command` preset for Windows provides many of keys as below. Generally, you can pick up the columns with `keys` option.
+If you need additional keys, consider to update `command` option.
 
 `````powershell
 powershell -command "Get-Process -IncludeUserName

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ $ tail -f /var/log/td-agent/td-agent.log
   * to use short hostname, set `hostname -s` for this option on linux/mac.
   * [default] `hostname`
 
+* powershell_command (Optional)
+  * settings for powershell command name. PowerShell Core had been renamed its command to `pwsh` and PowerShell 7 continues to use `pwsh` as its command name.
+  * [default] `powershell`
+  * [avaliables] `powershell`, `pwsh`
+
 ### About Windows
 
 Default `command` in Windows below is complicated, but you can fix `keys` without fixing `command`, unless you specify a key other than the default.
@@ -127,6 +132,8 @@ Here are details of this default command.
   * this formats objects to csv strings.
   * currently, it is needed that `command` outputs the results in csv format.
     * this is because white space delimiter is not suitable for Windows, in which empty values are often mixed.
+
+**Note:** When using with PowerShell 7 which is previously known as PowerShell Core, you must specify `powershell_command` parameter as `pwsh`. Otherwise, this plugin does not work correctly on PowerShell 7 (pwsh). This is because PowerShell Core and PowerShell 7 use different command name which is `pwsh` not `powershell`.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,8 @@ Default `command` in Windows below is complicated, but you can fix `keys` withou
 powershell -command "Get-Process -IncludeUserName
  | ?{$_.StartTime -ne $NULL -and $_.CPU -ne $NULL}
  | Select-Object -Property StartTime,UserName,SessionId,Id,CPU,WorkingSet,VirtualMemorySize,HandleCount,ProcessName
- | %{
-  $_.StartTime = $_.StartTime.ToString(
-  'ddd MMM dd HH:mm:ss yyyy',
-  [Globalization.CultureInfo]::GetCultureInfo('en-US').DateTimeFormat
-  );
-  return $_;
-} | ConvertTo-Csv -NoTypeInformation"
+ | %{$_.StartTime = $_.StartTime.ToString('o'); return $_;}
+ | ConvertTo-Csv -NoTypeInformation"
 `````
 
 Here are details of this default command.
@@ -125,8 +120,8 @@ Here are details of this default command.
 * ` | Select-Object -Property ...`
   * this takes the necessary parameters from `System.Diagnostics.Process` objects.
   * `...` part will be automatically fixed by `keys`.
-* ` | %{$_.StartTime = ...; return $_;}`
-  * this fixes locale of `StartTime` value to `en-US`.
+* ` | %{$_.StartTime = $_.StartTime.ToString('o'); return $_;}`
+  * this fixes the format of `StartTime` value.
   * note: in Windows, setting the "$env:Lang" environment variable is not effective in changing the format of the output.
 * ` | ConvertTo-Csv -NoTypeInformation`
   * this formats objects to csv strings.

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -201,20 +201,13 @@ module Fluent::Plugin
         " | Select-Object -Property #{@keys.join(',')}"
       end
 
-      def pipe_fixing_locale(format: "ddd MMM dd HH:mm:ss yyyy", locale: "en-US")
+      def pipe_fixing_locale()
         # In Windows, setting the "$env:Lang" environment variable is not effective in changing the format of the output.
         # You can use "Datetime.ToString" method to change format of datetime values in for-each pipe.
         # Note: About "DateTime.ToString" method: https://docs.microsoft.com/en-us/dotnet/api/system.datetime.tostring
-        # Note: About "Custom date and time format strings": https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
         return "" unless @keys.include?("StartTime")
 
-        " | %{
-          $_.StartTime = $_.StartTime.ToString(
-            '#{format}',
-            [Globalization.CultureInfo]::GetCultureInfo('#{locale}').DateTimeFormat
-          ); 
-          return $_;
-        }"
+        " | %{$_.StartTime = $_.StartTime.ToString('o'); return $_;}"
       end
 
       def pipe_formatting_output

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -148,7 +148,9 @@ module Fluent::Plugin
         data = Hash[@keys.zip(values)]
 
         unless data["StartTime"].nil?
-          data["StartTime"] = format_datetime(data["StartTime"])
+          start_time = Time.parse(data['StartTime'])
+          data['ElapsedTime'] = (Time.now - start_time).to_i
+          data["StartTime"] = start_time.to_s
         end
 
         data
@@ -181,10 +183,6 @@ module Fluent::Plugin
       end
 
       private
-
-      def format_datetime(datetime)
-        Time.parse(datetime).to_s
-      end
 
       def pipe_filtering_normal_ps
         # There are some special processes that don't have some properties, such as the "Idle" process.

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -89,32 +89,17 @@ module Fluent::Plugin
     end
 
     def get_ps_command
-      if OS.linux?
-        "LANG=en_US.UTF-8 && ps -ewwo lstart,user:20,pid,ppid,time,%cpu,%mem,rss,sz,s,comm,cmd"
-      elsif OS.mac?
+      if mac?
         "LANG=en_US.UTF-8 && ps -ewwo lstart,user,pid,ppid,time,%cpu,%mem,rss,vsz,state,comm,command"
       elsif Fluent.windows?
         @windows_watcher.command
+      else
+        "LANG=en_US.UTF-8 && ps -ewwo lstart,user:20,pid,ppid,time,%cpu,%mem,rss,sz,s,comm,cmd"
       end
     end
 
-    module OS
-      # ref. http://stackoverflow.com/questions/170956/how-can-i-find-which-operating-system-my-ruby-program-is-running-on
-      def OS.windows?
-        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-      end
-
-      def OS.mac?
-       (/darwin/ =~ RUBY_PLATFORM) != nil
-      end
-
-      def OS.unix?
-        !OS.windows?
-      end
-
-      def OS.linux?
-        OS.unix? and not OS.mac?
-      end
+    def mac?
+      (/darwin/ =~ RUBY_PLATFORM) != nil
     end
 
     class WindowsWatcher

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -147,7 +147,13 @@ module Fluent::Plugin
 
       def parse_line(line)
         values = line.chomp.strip.parse_csv.map { |e| e ? e : "" }
-        Hash[@keys.zip(values)]
+        data = Hash[@keys.zip(values)]
+
+        unless data["start_time"].nil?
+          data["start_time"] = format_datetime(data["start_time"])
+        end
+
+        data
       end
 
       def default_command
@@ -171,6 +177,10 @@ module Fluent::Plugin
       end
 
       private
+
+      def format_datetime(datetime)
+        Time.parse(datetime).to_s
+      end
 
       def pipe_filtering_normal_ps
         # There are some special processes that don't have some properties, such as the "Idle" process.

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'csv' if Fluent.windows?
 require "fluent/plugin/input"
 require 'fluent/mixin/rewrite_tag_name'
 require 'fluent/mixin/type_converter'
@@ -14,7 +15,7 @@ module Fluent::Plugin
 
     config_param :tag, :string
     config_param :command, :string, :default => nil
-    config_param :keys, :array, :default => DEFAULT_KEYS
+    config_param :keys, :array, :default => nil
     config_param :interval, :time, :default => '5s'
     config_param :lookup_user, :array, :default => nil
     config_param :hostname_command, :string, :default => 'hostname'
@@ -22,7 +23,6 @@ module Fluent::Plugin
     include Fluent::HandleTagNameMixin
     include Fluent::Mixin::RewriteTagName
     include Fluent::Mixin::TypeConverter
-    config_set_default :types, DEFAULT_TYPES
 
     def initialize
       super
@@ -31,7 +31,10 @@ module Fluent::Plugin
     def configure(conf)
       super
 
-      @command = @command || get_ps_command
+      @windows_watcher = WindowsWatcher.new(@keys, @command) if Fluent.windows?
+      @keys ||= Fluent.windows? ? @windows_watcher.keys : DEFAULT_KEYS
+      @command ||= get_ps_command
+      apply_default_types
       log.info "watch_process: polling start. :tag=>#{@tag} :lookup_user=>#{@lookup_user} :interval=>#{@interval} :command=>#{@command}"
     end
 
@@ -44,19 +47,21 @@ module Fluent::Plugin
       super
     end
 
+    def apply_default_types
+      return unless @types.nil?
+      @types = Fluent.windows? ? @windows_watcher.default_types : DEFAULT_TYPES
+      @type_converters = parse_types_parameter unless @types.nil?
+    end
+
     def on_timer
       io = IO.popen(@command, 'r')
       io.gets
       while result = io.gets
-        keys_size = @keys.size
-        if result =~ /(?<lstart>(^\w+\s+\w+\s+\d+\s+\d\d:\d\d:\d\d \d+))/
-          lstart = Time.parse($~[:lstart])
-          result = result.sub($~[:lstart], '')
-          keys_size -= 1
+        if Fluent.windows?
+          data = @windows_watcher.parse_line(result)
+        else
+          data = parse_line(result)
         end
-        values = [lstart.to_s, result.chomp.strip.split(/\s+/, keys_size)]
-        data = Hash[@keys.zip(values.reject(&:empty?).flatten)]
-        data['elapsed_time'] = (Time.now - Time.parse(data['start_time'])).to_i if data['start_time']
         next unless @lookup_user.nil? || @lookup_user.include?(data['user'])
         emit_tag = tag.dup
         filter_record(emit_tag, Fluent::Engine.now, data)
@@ -67,11 +72,26 @@ module Fluent::Plugin
       log.error "watch_process: error has occured. #{e.message}"
     end
 
+    def parse_line(line)
+      keys_size = @keys.size
+      if line =~ /(?<lstart>(^\w+\s+\w+\s+\d+\s+\d\d:\d\d:\d\d \d+))/
+        lstart = Time.parse($~[:lstart])
+        line = line.sub($~[:lstart], '')
+        keys_size -= 1
+      end
+      values = [lstart.to_s, line.chomp.strip.split(/\s+/, keys_size)]
+      data = Hash[@keys.zip(values.reject(&:empty?).flatten)]
+      data['elapsed_time'] = (Time.now - Time.parse(data['start_time'])).to_i if data['start_time']
+      data
+    end
+
     def get_ps_command
       if OS.linux?
         "LANG=en_US.UTF-8 && ps -ewwo lstart,user:20,pid,ppid,time,%cpu,%mem,rss,sz,s,comm,cmd"
       elsif OS.mac?
         "LANG=en_US.UTF-8 && ps -ewwo lstart,user,pid,ppid,time,%cpu,%mem,rss,vsz,state,comm,command"
+      elsif Fluent.windows?
+        @windows_watcher.command
       end
     end
 
@@ -91,6 +111,113 @@ module Fluent::Plugin
 
       def OS.linux?
         OS.unix? and not OS.mac?
+      end
+    end
+
+    class WindowsWatcher
+      # Values are from the "System.Diagnostics.Process" object properties that can be taken by the "Get-Process" command.
+      # You can check the all properties by the "(Get-Process)[0] | Get-Member" command.
+      DEFAULT_PARAMS = {
+        "start_time" => "StartTime",
+        "user" => "UserName",
+        "sid" => "SessionId",
+        "pid" => "Id",
+        "cpu_second" => "CPU",
+        "working_set" => "WorkingSet",
+        "virtual_memory_size" => "VirtualMemorySize",
+        "handles" => "HandleCount",
+        "proc_name" => "ProcessName",
+      }
+
+      DEFAULT_TYPES = %w(
+        sid:integer
+        pid:integer
+        cpu_second:float
+        working_set:integer
+        virtual_memory_size:integer
+        handles:integer
+      ).join(",")
+
+      attr_reader :keys
+      attr_reader :command
+
+      def initialize(keys, command)
+        @keys = keys || DEFAULT_PARAMS.keys
+        @command = command || default_command
+      end
+
+      def default_types
+        DEFAULT_TYPES
+      end
+
+      def parse_line(line)
+        values = line.chomp.strip.parse_csv.map { |e| e ? e : "" }
+        Hash[@keys.zip(values)]
+      end
+
+      def default_command
+        command = [
+          command_ps,
+          pipe_filtering_normal_ps,
+          pipe_select_columns,
+          pipe_fixing_locale,
+          pipe_formatting_output,
+        ].join
+        "powershell -command \"#{command}\""
+      end
+
+      def command_ps
+        if @keys.include?("user")
+          # The "IncludeUserName" option is needed to get the username, but this option requires Administrator privilege.
+          "Get-Process -IncludeUserName"
+        else
+          "Get-Process"
+        end
+      end
+
+      private
+
+      def pipe_filtering_normal_ps
+        # There are some special processes that don't have some properties, such as the "Idle" process.
+        # Normally, these are specific to the system and are not important, so exclude them.
+        # Note: The same situation can occur in some processes if there are no Administrator privilege.
+        " | ?{$_.StartTime -ne $NULL -and $_.CPU -ne $NULL}"
+      end
+
+      def pipe_select_columns
+        columns = @keys.map { |key|
+          next unless DEFAULT_PARAMS.keys.include?(key)
+          DEFAULT_PARAMS[key]
+        }.compact
+
+        if columns.nil? || columns.empty?
+          raise "The 'keys' parameter is not specified correctly. [keys: #{@keys}]"
+        end
+
+        " | Select-Object -Property #{columns.join(',')}"
+      end
+
+      def pipe_fixing_locale(format: "ddd MMM dd HH:mm:ss yyyy", locale: "en-US")
+        # In Windows, setting the "$env:Lang" environment variable is not effective in changing the format of the output.
+        # You can use "Datetime.ToString" method to change format of datetime values in for-each pipe.
+        # Note: About "DateTime.ToString" method: https://docs.microsoft.com/en-us/dotnet/api/system.datetime.tostring
+        # Note: About "Custom date and time format strings": https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+        return "" unless @keys.include?("start_time")
+
+        " | %{
+          $_.StartTime = $_.StartTime.ToString(
+            '#{format}',
+            [Globalization.CultureInfo]::GetCultureInfo('#{locale}').DateTimeFormat
+          ); 
+          return $_;
+        }"
+      end
+
+      def pipe_formatting_output
+        # In the "ConvertTo-Csv" command, there are 2 lines of type info and header info at the beginning in the outputs.
+        # By the "NoTypeInformation" option, the line of type info is excluded.
+        # This enables you to skip the just first line for parsing, like linux or mac.
+        " | ConvertTo-Csv -NoTypeInformation"
       end
     end
   end

--- a/lib/fluent/plugin/in_watch_process.rb
+++ b/lib/fluent/plugin/in_watch_process.rb
@@ -11,7 +11,14 @@ module Fluent::Plugin
     helpers :timer
 
     DEFAULT_KEYS = %w(start_time user pid parent_pid cpu_time cpu_percent memory_percent mem_rss mem_size state proc_name command)
-    DEFAULT_TYPES = "pid:integer,parent_pid:integer,cpu_percent:float,memory_percent:float,mem_rss:integer,mem_size:integer"
+    DEFAULT_TYPES = %w(
+      pid:integer
+      parent_pid:integer
+      cpu_percent:float
+      memory_percent:float
+      mem_rss:integer
+      mem_size:integer
+    ).join(",")
 
     config_param :tag, :string
     config_param :command, :string, :default => nil

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -25,7 +25,8 @@ class WatchProcessInputTest < Test::Unit::TestCase
     assert_equal ['apache', 'mycron'], d.instance.lookup_user
   end
 
-  def test_emit
+  def test_unixlike
+    return if Fluent.windows?
     whoami = `whoami`
     d = create_driver %[
       tag          input.watch_process
@@ -34,5 +35,76 @@ class WatchProcessInputTest < Test::Unit::TestCase
     ]
     d.run(expect_emits: 1, timeout: 3)
     assert(d.events.size > 1)
+  end
+
+  def test_windows_default
+    return unless Fluent.windows?
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+    ]
+    default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_PARAMS.keys
+
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    tag, time, record = d.events[0]
+
+    assert_equal "input.watch_process", tag
+    assert time.is_a?(Fluent::EventTime)
+    assert_equal default_keys, record.keys
+  end
+
+  def test_windows_customized
+    return unless Fluent.windows?
+    custom_keys = ["handles", "pid", "proc_name"]
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+      keys #{custom_keys.join(",")}
+      types pid:integer
+    ]
+
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    tag, time, record = d.events[0]
+
+    assert_equal "input.watch_process", tag
+    assert time.is_a?(Fluent::EventTime)
+    assert_equal custom_keys, record.keys
+    assert record["handles"].is_a?(String)
+    assert record["pid"].is_a?(Integer)
+  end
+
+  def test_windows_lookup
+    return unless Fluent.windows?
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+    ]
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    tag, time, record = d.events[0]
+    lookup_user = record["user"]
+
+    d = create_driver %[
+      tag input.watch_process
+      interval 1s
+      lookup_user #{lookup_user}
+    ]
+    d.run(expect_records: 1, timeout: 10);
+
+    assert d.events.size > 0
+
+    other_user_records = d.events.reject do |tag, time, record|
+      lookup_user.include?(record["user"])
+    end
+
+    assert other_user_records.size == 0
   end
 end

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -26,7 +26,7 @@ class WatchProcessInputTest < Test::Unit::TestCase
   end
 
   def test_unixlike
-    return if Fluent.windows?
+    omit "Only for UNIX like." if Fluent.windows?
     whoami = `whoami`
     d = create_driver %[
       tag          input.watch_process
@@ -37,74 +37,76 @@ class WatchProcessInputTest < Test::Unit::TestCase
     assert(d.events.size > 1)
   end
 
-  def test_windows_default
-    return unless Fluent.windows?
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-    ]
-    default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_PARAMS.keys
+  sub_test_case "Windows" do
+    def test_windows_default
+      omit "Only for Windows." unless Fluent.windows?
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+      ]
+      default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_PARAMS.keys
 
-    d.run(expect_records: 1, timeout: 10);
+      d.run(expect_records: 1, timeout: 10);
 
-    assert d.events.size > 0
+      assert d.events.size > 0
 
-    tag, time, record = d.events[0]
+      tag, time, record = d.events[0]
 
-    assert_equal "input.watch_process", tag
-    assert time.is_a?(Fluent::EventTime)
-    assert_equal default_keys, record.keys
-  end
-
-  def test_windows_customized
-    return unless Fluent.windows?
-    custom_keys = ["handles", "pid", "proc_name"]
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-      keys #{custom_keys.join(",")}
-      types pid:integer
-    ]
-
-    d.run(expect_records: 1, timeout: 10);
-
-    assert d.events.size > 0
-
-    tag, time, record = d.events[0]
-
-    assert_equal "input.watch_process", tag
-    assert time.is_a?(Fluent::EventTime)
-    assert_equal custom_keys, record.keys
-    assert record["handles"].is_a?(String)
-    assert record["pid"].is_a?(Integer)
-  end
-
-  def test_windows_lookup
-    return unless Fluent.windows?
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-    ]
-    d.run(expect_records: 1, timeout: 10);
-
-    assert d.events.size > 0
-
-    tag, time, record = d.events[0]
-    lookup_user = record["user"]
-
-    d = create_driver %[
-      tag input.watch_process
-      interval 1s
-      lookup_user #{lookup_user}
-    ]
-    d.run(expect_records: 1, timeout: 10);
-
-    assert d.events.size > 0
-
-    other_user_records = d.events.reject do |tag, time, record|
-      lookup_user.include?(record["user"])
+      assert_equal "input.watch_process", tag
+      assert time.is_a?(Fluent::EventTime)
+      assert_equal default_keys, record.keys
     end
 
-    assert other_user_records.size == 0
+    def test_windows_customized
+      omit "Only for Windows." unless Fluent.windows?
+      custom_keys = ["handles", "pid", "proc_name"]
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+        keys #{custom_keys.join(",")}
+        types pid:integer
+      ]
+
+      d.run(expect_records: 1, timeout: 10);
+
+      assert d.events.size > 0
+
+      tag, time, record = d.events[0]
+
+      assert_equal "input.watch_process", tag
+      assert time.is_a?(Fluent::EventTime)
+      assert_equal custom_keys, record.keys
+      assert record["handles"].is_a?(String)
+      assert record["pid"].is_a?(Integer)
+    end
+
+    def test_windows_lookup
+      omit "Only for Windows." unless Fluent.windows?
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+      ]
+      d.run(expect_records: 1, timeout: 10);
+
+      assert d.events.size > 0
+
+      tag, time, record = d.events[0]
+      lookup_user = record["user"]
+
+      d = create_driver %[
+        tag input.watch_process
+        interval 1s
+        lookup_user #{lookup_user}
+      ]
+      d.run(expect_records: 1, timeout: 10);
+
+      assert d.events.size > 0
+
+      other_user_records = d.events.reject do |tag, time, record|
+        lookup_user.include?(record["user"])
+      end
+
+      assert other_user_records.size == 0
+    end
   end
 end

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -23,6 +23,19 @@ class WatchProcessInputTest < Test::Unit::TestCase
     ]
     assert_equal 'input.watch_process', d.instance.tag
     assert_equal ['apache', 'mycron'], d.instance.lookup_user
+    assert_equal :powershell, d.instance.powershell_command
+  end
+
+  def test_windows_configure
+    omit "Only for UNIX like." unless Fluent.windows?
+    d = create_driver %[
+      tag          input.watch_process
+      lookup_user  apache, mycron
+      powershell_command pwsh
+    ]
+    assert_equal 'input.watch_process', d.instance.tag
+    assert_equal ['apache', 'mycron'], d.instance.lookup_user
+    assert_equal :pwsh, d.instance.powershell_command
   end
 
   def test_unixlike

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -44,7 +44,7 @@ class WatchProcessInputTest < Test::Unit::TestCase
         tag input.watch_process
         interval 1s
       ]
-      default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_PARAMS.keys
+      default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_KEYS
 
       d.run(expect_records: 1, timeout: 10);
 
@@ -59,12 +59,12 @@ class WatchProcessInputTest < Test::Unit::TestCase
 
     def test_windows_customized
       omit "Only for Windows." unless Fluent.windows?
-      custom_keys = ["handles", "pid", "proc_name"]
+      custom_keys = ["PM", "Id", "UserProcessorTime", "Path"]
       d = create_driver %[
         tag input.watch_process
         interval 1s
         keys #{custom_keys.join(",")}
-        types pid:integer
+        types Id:integer
       ]
 
       d.run(expect_records: 1, timeout: 10);
@@ -76,8 +76,8 @@ class WatchProcessInputTest < Test::Unit::TestCase
       assert_equal "input.watch_process", tag
       assert time.is_a?(Fluent::EventTime)
       assert_equal custom_keys, record.keys
-      assert record["handles"].is_a?(String)
-      assert record["pid"].is_a?(Integer)
+      assert record["PM"].is_a?(String)
+      assert record["Id"].is_a?(Integer)
     end
 
     def test_windows_lookup
@@ -91,7 +91,7 @@ class WatchProcessInputTest < Test::Unit::TestCase
       assert d.events.size > 0
 
       tag, time, record = d.events[0]
-      lookup_user = record["user"]
+      lookup_user = record["UserName"]
 
       d = create_driver %[
         tag input.watch_process
@@ -103,7 +103,7 @@ class WatchProcessInputTest < Test::Unit::TestCase
       assert d.events.size > 0
 
       other_user_records = d.events.reject do |tag, time, record|
-        lookup_user.include?(record["user"])
+        lookup_user.include?(record["UserName"])
       end
 
       assert other_user_records.size == 0

--- a/test/plugin/test_in_watch_process.rb
+++ b/test/plugin/test_in_watch_process.rb
@@ -44,7 +44,7 @@ class WatchProcessInputTest < Test::Unit::TestCase
         tag input.watch_process
         interval 1s
       ]
-      default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_KEYS
+      default_keys = Fluent::Plugin::WatchProcessInput::WindowsWatcher::DEFAULT_KEYS + ["ElapsedTime"]
 
       d.run(expect_records: 1, timeout: 10);
 


### PR DESCRIPTION
This adds Windows support.

I added default configuration values for Windows, and separated the parsing logic.

The command for Windows had to be complicated, 
but I made it possible to change the keys without setting the command in Windows
so that users don't have to understand Windows command.
